### PR TITLE
allow updating a components priority

### DIFF
--- a/lib/src/components/base_component.dart
+++ b/lib/src/components/base_component.dart
@@ -52,6 +52,8 @@ abstract class BaseComponent extends Component {
 
   TextConfig get debugTextConfig => TextConfig(color: debugColor, fontSize: 12);
 
+  BaseComponent({int priority}) : super(priority: priority);
+
   /// This method is called periodically by the game engine to request that your component updates itself.
   ///
   /// The time [dt] in seconds (with microseconds precision provided by Flutter) since the last update cycle.

--- a/lib/src/components/component.dart
+++ b/lib/src/components/component.dart
@@ -27,7 +27,7 @@ abstract class Component {
   /// The smaller the priority, the sooner your component will be updated/rendered.
   /// It can be any integer (negative, zero, or positive).
   /// If two components share the same priority, they will probably be drawn in the order they were added.
-  final int priority;
+  int priority;
 
   /// Whether this component should be removed or not.
   ///

--- a/lib/src/components/position_component.dart
+++ b/lib/src/components/position_component.dart
@@ -123,8 +123,10 @@ abstract class PositionComponent extends BaseComponent {
     this.anchor = Anchor.topLeft,
     this.renderFlipX = false,
     this.renderFlipY = false,
+    int priority,
   })  : position = position ?? Vector2.zero(),
-        size = size ?? Vector2.zero();
+        size = size ?? Vector2.zero(),
+        super(priority: priority);
 
   @override
   bool containsPoint(Vector2 point) {

--- a/lib/src/components/sprite_component.dart
+++ b/lib/src/components/sprite_component.dart
@@ -30,7 +30,8 @@ class SpriteComponent extends PositionComponent {
     Vector2 size,
     this.sprite,
     this.overridePaint,
-  }) : super(position: position, size: size);
+    int priority,
+  }) : super(position: position, size: size, priority: priority);
 
   factory SpriteComponent.fromImage(
     Image image, {

--- a/lib/src/game/base_game.dart
+++ b/lib/src/game/base_game.dart
@@ -41,6 +41,12 @@ class BaseGame extends Game with FPSCounter {
   /// concurrency issues.
   final Set<Component> _removeLater = {};
 
+  /// Components to have their priority updated on the next update
+  ///
+  /// The component list is only changed at the start of each [update] to avoid
+  /// concurrency issues.
+  final Map<Component, int> _updatePriorityLater = {};
+
   /// The camera translates the coordinate space after the viewport is applied.
   final Camera camera = Camera();
 
@@ -152,6 +158,11 @@ class BaseGame extends Game with FPSCounter {
     _removeLater.addAll(components);
   }
 
+  /// Marks a component to have its priority updated on the next game tick
+  void updateComponentPriority(Component c, int priority) {
+    _updatePriorityLater[c] = priority;
+  }
+
   /// This implementation of render basically calls [renderComponent] for every component, making sure the canvas is reset for each one.
   ///
   /// You can override it further to add more custom behavior.
@@ -201,6 +212,18 @@ class BaseGame extends Game with FPSCounter {
       _addLater.clear();
       components.addAll(addNow);
       addNow.forEach((component) => component.onMount());
+    }
+
+    if (_updatePriorityLater.isNotEmpty) {
+      final updateNow = _updatePriorityLater.entries.toList(growable: false);
+
+      _updatePriorityLater.clear();
+
+      updateNow.forEach((entry) {
+        components.remove(entry.key);
+        entry.key.priority = entry.value;
+        components.add(entry.key);
+      });
     }
 
     components.forEach((c) => c.update(dt));


### PR DESCRIPTION
Make Component priority property non-final and update component constructors to allow setting priority

add updateComponentPriority function in BaseGame to mark that a component needs to have its priority updated in the next game tick